### PR TITLE
Possible fix for a `string type unbound` prover warning

### DIFF
--- a/mlw/archetype.mlw
+++ b/mlw/archetype.mlw
@@ -20,7 +20,7 @@ theory Types
   exception InvalidCondition
   exception NoTransfer
   exception InvalidState
-  exception Invalid string
+  exception Invalid astring
 end
 
 module Utils


### PR DESCRIPTION
I have no idea if this fix is making sense, but somehow my `why3` prover would not start correctly and show a warning. The warning said something along the line `type string is not bind in archetype.mlw`. I found this file and just made a blind guess. And it helped :)
Should it be `astring` there? Again I have no idea what I'm doing.