### PR TITLE
Remove dependency on non-existing ppx_deriving

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -26,7 +26,7 @@
   binding gen_contract_interface compile
   lsp services
   )
-  (libraries menhirLib num str ppx_deriving yojson ppx_deriving_yojson.runtime hex unix xmlm)
+  (libraries menhirLib num str yojson ppx_deriving_yojson.runtime hex unix xmlm)
  (flags :standard -w -30  ; Allow sharing of record labels between distinct types.
                   -w -7   ; Allow overridden methods between visitors-generated classes.
                   -w -17) ; Allow visit_big_int not to be declared.


### PR DESCRIPTION
When the ppx_deriving package is vendored and not installed with dune the library "ppx_deriving" can't be located. ppx_deriving contains several libraries under the "ppx_deriving." prefix, but not library simply named "ppx_deriving". This works when ppx_deriving is installed with opam due to inconsistencies with how dune locates libraries between vendored and opam-installed packages.